### PR TITLE
Minor fixes for PDP type and connection timing

### DIFF
--- a/applications/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
+++ b/applications/luci-proto-quectel/htdocs/luci-static/resources/protocol/quectel.js
@@ -99,7 +99,7 @@ return network.registerProtocol('quectel', {
 
 		o = s.taboption('advanced', form.Value, 'delay', _('Modem init timeout'),
 			_('Maximum amount of seconds to wait for the modem to become ready'));
-		o.placeholder = '10';
+		o.placeholder = '20';
 		o.datatype    = 'min(1)';
 
 		o = s.taboption('advanced', form.Value, 'mtu', _('Override MTU'));

--- a/utils/quectel-cm/files/quectel.sh
+++ b/utils/quectel-cm/files/quectel.sh
@@ -66,7 +66,7 @@ proto_quectel_setup() {
 		return 1
 	}
 
-	[ "$pdptype" = "ip" -o "$pdptype" = "ipv4v6" ] && ipv4opt="-4"
+	[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv4v6" ] && ipv4opt="-4"
 	[ "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && ipv6opt="-6"
 	[ -n "$auth" ] || auth="none"
 
@@ -105,7 +105,7 @@ proto_quectel_setup() {
 		ubus call network add_dynamic "$(json_dump)"
 	fi
 
-	if [ "$pdptype" = "ip" ] || [ "$pdptype" = "ipv4v6" ]; then
+	if [ "$pdptype" = "ipv4" ] || [ "$pdptype" = "ipv4v6" ]; then
 		json_init
 		json_add_string name "${interface}_4"
 		json_add_string ifname "@$interface"


### PR DESCRIPTION
This pull request introduces minor adjustments to improve modem behavior and connection reliability:

- Corrects the PDP type used during connection setup
- Increases the modem wait time to allow proper initialization

These changes aim to enhance compatibility and stability across different Quectel/Fibocom modem models and network conditions.